### PR TITLE
Add default value for collection max size if not available in

### DIFF
--- a/set-definitions/src/main/java/eu/europeana/set/definitions/config/UserSetConfiguration.java
+++ b/set-definitions/src/main/java/eu/europeana/set/definitions/config/UserSetConfiguration.java
@@ -17,6 +17,11 @@ public interface UserSetConfiguration {
   @Deprecated
   public String getUserSetBaseUrl();
 
+  /**
+   * Indicates the maximum number of items to be included for serialization of collection pages
+   * @param profile currently not used, might be used in the future to use different sizes for different profiles
+   * @return the configured value as present, or the hardcoded default value otherwise
+   */
   public int getMaxPageSize(String profile);
 
   public int getMaxSearchDereferencedItems();

--- a/set-definitions/src/main/java/eu/europeana/set/definitions/config/UserSetConfigurationImpl.java
+++ b/set-definitions/src/main/java/eu/europeana/set/definitions/config/UserSetConfigurationImpl.java
@@ -12,11 +12,8 @@ public class UserSetConfigurationImpl implements UserSetConfiguration {
   public static final String KEY_RETRIEVE_DEREFERENCE_ITEMS = "set.retrieve.dereference.items.max";
 
   public static final int DEFAULT_ITEMS_PER_PAGE = 10;
-  @Deprecated
-  /**
-   * use getMaxPageSize instead
-   */
-  public static final int MAX_ITEMS_TO_PRESENT = 1000;
+  public static final int DEFAULT_MAX_COLLECTION_SIZE = 100;
+  public static final int DEFAULT_MAX_ITEMS_TO_PRESENT = 1000;
 
 
   public static final String SET_API_ENDPOINT = "set.api.endpoint.baseUrl";
@@ -110,7 +107,7 @@ public class UserSetConfigurationImpl implements UserSetConfiguration {
   public int getMaxPageSize(String profile) {
     // TODO enable configuration per profile when specified
     String key = PREFIX_RETRIEVE_MAX_PAGE_SIZE + LdProfiles.STANDARD.name().toLowerCase();
-    return Integer.parseInt(getSetProperties().getProperty(key));
+    return Integer.parseInt(getSetProperties().getProperty(key, ""+DEFAULT_MAX_ITEMS_TO_PRESENT));
   }
 
   public int getMaxSearchDereferencedItems() {
@@ -186,6 +183,6 @@ public class UserSetConfigurationImpl implements UserSetConfiguration {
   
   @Override
   public int getCollectionMaxSize() {
-    return Integer.parseInt(getSetProperties().getProperty(COLLECTION_SIZE_MAX));
+    return Integer.parseInt(getSetProperties().getProperty(COLLECTION_SIZE_MAX, ""+DEFAULT_MAX_COLLECTION_SIZE));
   }
 }

--- a/set-web/src/main/java/eu/europeana/set/web/service/impl/UserSetServiceImpl.java
+++ b/set-web/src/main/java/eu/europeana/set/web/service/impl/UserSetServiceImpl.java
@@ -848,9 +848,10 @@ public class UserSetServiceImpl extends BaseUserSetServiceImpl {
     // presented
     if (profile != LdProfiles.MINIMAL && userSet.getItems() != null) {
       int itemsCount = userSet.getItems().size();
-      if (itemsCount > UserSetConfigurationImpl.MAX_ITEMS_TO_PRESENT) {
+      final int maxPageSize = getConfiguration().getMaxPageSize(profile.getRequestParamValue());
+      if (itemsCount > maxPageSize) {
         List<String> itemsPage =
-            userSet.getItems().subList(0, UserSetConfigurationImpl.MAX_ITEMS_TO_PRESENT);
+            userSet.getItems().subList(0, maxPageSize);
         userSet.setItems(itemsPage);
         profile = LdProfiles.STANDARD;
         getLogger().debug("Profile switched to standard, due to set size!");


### PR DESCRIPTION
configurations, improve handling of max items presented in search results.  #EA-3871